### PR TITLE
Switch to DiffEq

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6.0-pre
-ODE
+julia 0.6.0
+OrdinaryDiffEq
 RecipesBase
 Requires

--- a/src/DMP2dof.jl
+++ b/src/DMP2dof.jl
@@ -65,7 +65,7 @@ function solve_canonical(dmp::DMP2dof, t, y0, g, solver)
     e   = zeros(T,n)
     x   = zeros(T)
     for i = 1:n
-        function time_derivative(t,state)
+        function time_derivative(t,state,dstate)
             local yc  = state[1]
             local ẏc  = state[2]
             local ya  = state[3]
@@ -73,7 +73,12 @@ function solve_canonical(dmp::DMP2dof, t, y0, g, solver)
             local e   = state[5]
             local x   = state[6]
             ẏc,ÿc,ẏa,ÿa,ė,ẋ = acceleration(dmp,yc,ẏc,x,ya,ẏa,e,g[i],i)
-            [ẏc,ÿc,ẏa,ÿa,ė,ẋ]
+            dstate[1] = ẏc
+            dstate[2] = ÿc
+            dstate[3] = ẏa
+            dstate[4] = ÿa
+            dstate[5] = ė
+            dstate[6] = ẋ
         end
         state0 = [y0[i], dmp.ẏ[1,i], y0[i], dmp.ẏ[1,i], 0, 1.]
         prob = OrdinaryDiffEq.ODEProblem(time_derivative,state0,(t[1],t[end]))

--- a/src/DMP2dof.jl
+++ b/src/DMP2dof.jl
@@ -65,7 +65,7 @@ function solve_canonical(dmp::DMP2dof, t, y0, g, solver)
     e   = zeros(T,n)
     x   = zeros(T)
     for i = 1:n
-        function time_derivative(t,state,dstate)
+        function time_derivative(dstate, state, p, t)
             local yc  = state[1]
             local ẏc  = state[2]
             local ya  = state[3]

--- a/src/DMP2dof.jl
+++ b/src/DMP2dof.jl
@@ -76,14 +76,14 @@ function solve_canonical(dmp::DMP2dof, t, y0, g, solver)
             [ẏc,ÿc,ẏa,ÿa,ė,ẋ]
         end
         state0 = [y0[i], dmp.ẏ[1,i], y0[i], dmp.ẏ[1,i], 0, 1.]
-        tout,state_history = solver(time_derivative, state0, t,points=:specified)
-        res      = vv2m(state_history)
-        yc[:,i]  = res[:,1]
-        ẏc[:,i]  = res[:,2]
-        ya[:,i]  = res[:,3]
-        ẏa[:,i]  = res[:,4]
-        e[:,i]   = res[:,5]
-        x[:]     = res[6] # TODO: se till att denna är samma för alla DOF
+        prob = OrdinaryDiffEq.ODEProblem(time_derivative,state0,(t[1],t[end]))
+        sol = OrdinaryDiffEq.solve(prob,solver,saveat=t,dt=t[2])
+        yc[:,i]  = sol[1,:]
+        ẏc[:,i]  = sol[2,:]
+        ya[:,i]  = sol[3,:]
+        ẏa[:,i]  = sol[4,:]
+        e[:,i]   = sol[5,:]
+        x[:]     = sol[6,:] # TODO: se till att denna är samma för alla DOF
     end
     t,yc,ẏc,x,ya,ẏa,e
 end

--- a/src/DynamicMovementPrimitives.jl
+++ b/src/DynamicMovementPrimitives.jl
@@ -217,14 +217,13 @@ function solve_canonical(dmp::DMP, t, y0, g, solver)
     y   = zeros(T,n)
     x   = zeros(T)
     for i = 1:n
-        function time_derivative(t,state)
+        function time_derivative(t,state,dstate)
             local z   = state[1]
             local y   = state[2]
             local x   = state[3]
-            zp  = acceleration(dmp, y, z, x,g[i],i)
-            yp  = z
-            xp  = -αx/τ * x
-            [zp;yp;xp]
+            dstate[1] = acceleration(dmp, y, z, x,g[i],i)
+            dstate[2] = z
+            dstate[3] = -αx/τ * x
         end
         state0 = [dmp.ẏ[1,i]; y0[i]; 1.]
         prob = OrdinaryDiffEq.ODEProblem(time_derivative,state0,(t[1],t[end]))
@@ -243,12 +242,11 @@ function solve_position(dmp, t, y0, g, solver)
     z   = zeros(T,n)
     y   = zeros(T,n)
     for i = 1:n
-        function time_derivative(t,state)
+        function time_derivative(t,state,dstate)
             local z   = state[1]
             local y   = state[2]
-            zp  = acceleration(dmp, y, z, g[i]-y,g[i],i)
-            yp  = z
-            [zp;yp]
+            dstate[1] = acceleration(dmp, y, z, g[i]-y,g[i],i)
+            dstate[2] = z
         end
         state0  = [0; y0[i]]
         prob = OrdinaryDiffEq.ODEProblem(time_derivative,state0,(t[1],t[end]))
@@ -266,12 +264,11 @@ function solve_time(dmp, t, y0, g, solver)
     z       = zeros(T,n)
     y       = zeros(T,n)
     for i = 1:n
-        function time_derivative(t,state)
+        function time_derivative(t,state,dstate)
             local z   = state[1]
             local y   = state[2]
-            zp  = acceleration(dmp, y, z, t ,g[i],i)
-            yp  = z
-            [zp;yp]
+            dstate[1] = acceleration(dmp, y, z, t ,g[i],i)
+            dstate[2] = z
         end
         state0  = [0; y0[i]]
         prob = OrdinaryDiffEq.ODEProblem(time_derivative,state0,(t[1],t[end]))

--- a/src/DynamicMovementPrimitives.jl
+++ b/src/DynamicMovementPrimitives.jl
@@ -217,7 +217,7 @@ function solve_canonical(dmp::DMP, t, y0, g, solver)
     y   = zeros(T,n)
     x   = zeros(T)
     for i = 1:n
-        function time_derivative(t,state,dstate)
+        function time_derivative(dstate, state, p, t)
             local z   = state[1]
             local y   = state[2]
             local x   = state[3]
@@ -242,7 +242,7 @@ function solve_position(dmp, t, y0, g, solver)
     z   = zeros(T,n)
     y   = zeros(T,n)
     for i = 1:n
-        function time_derivative(t,state,dstate)
+        function time_derivative(dstate, state, p, t)
             local z   = state[1]
             local y   = state[2]
             dstate[1] = acceleration(dmp, y, z, g[i]-y,g[i],i)
@@ -264,7 +264,7 @@ function solve_time(dmp, t, y0, g, solver)
     z       = zeros(T,n)
     y       = zeros(T,n)
     for i = 1:n
-        function time_derivative(t,state,dstate)
+        function time_derivative(dstate, state, p, t)
             local z   = state[1]
             local y   = state[2]
             dstate[1] = acceleration(dmp, y, z, t ,g[i],i)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -57,10 +57,6 @@ function centraldiff(v::AbstractVector)
     a = a1+a2
 end
 
-"""Takes an n vector of m vectors and creates a n×m matrix"""
-vv2m(x::Vector) = [x[i][j] for i in eachindex(x), j in eachindex(x[1])]
-vv2m(x::Matrix) = x
-
 _1(y::VecOrMat) = y[1,:][:]
 _1(dmp::AbstractDMP) = _1(dmp.y)
 _T(dmp::AbstractDMP) = size(dmp.y,1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -172,6 +172,7 @@ dmp2 = DMP2dof(dmp, dmp2opts) # Upgrade dmp to 2DOF version
 
 t,yc,ẏc,x,ya,ẏa,e = solve(dmp2,t)
 
+#=
 function euler_disturbance(time_derivative, state0, t, args...; kwargs...)
     T = length(t)
     n = length(state0)
@@ -188,6 +189,7 @@ function euler_disturbance(time_derivative, state0, t, args...; kwargs...)
 end
 
 t,yc,ẏc,x,ya,ẏa,e = solve(dmp2,t, solver=euler_disturbance)
+=#
 # plot(t,ẏc, lab="\$ẏ_c\$", c=:red, l=(:dash, 3), layout=(2,2), subplot=1)
 # plot!(t,yc, lab="\$y_c\$", c=:red, l=(:dash, 3), subplot=2)
 # plot!(t,ẏa, lab="\$ẏ_a\$", c=:blue, subplot=1)
@@ -195,6 +197,7 @@ t,yc,ẏc,x,ya,ẏa,e = solve(dmp2,t, solver=euler_disturbance)
 # plot!(t,e, lab="\$e\$", c=:green, subplot=3)
 # plot!(t,400 .<= 1:T .< 600, lab="Disturbance", c=:green, subplot=4, fillrange=0)
 
-t,yc,ẏc,x,ya,ẏa,e = solve(dmp2,t, solver=euler)
+import OrdinaryDiffEq
+t,yc,ẏc,x,ya,ẏa,e = solve(dmp2,t, solver=OrdinaryDiffEq.Euler())
 # plot!(t,ẏc, lab="\$ẏ_u\$", c=:black, l=(:dashdot, 3), subplot=1)
 # plot!(t,yc, lab="\$y_u\$", c=:black, l=(:dashdot, 3), subplot=2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,6 +190,7 @@ end
 
 t,yc,ẏc,x,ya,ẏa,e = solve(dmp2,t, solver=euler_disturbance)
 =#
+
 # plot(t,ẏc, lab="\$ẏ_c\$", c=:red, l=(:dash, 3), layout=(2,2), subplot=1)
 # plot!(t,yc, lab="\$y_c\$", c=:red, l=(:dash, 3), subplot=2)
 # plot!(t,ẏa, lab="\$ẏ_a\$", c=:blue, subplot=1)


### PR DESCRIPTION
This PR switches from the basically deprecated ODE.jl to OrdinaryDiffEq.jl, the main ODE solver in DifferentialEquations.jl. `Tsit5()` was set as the default solver since it's the improved `ode45`. The derivative functions were made inplace to avoid allocations. I did not know what to do with the `euler_disturbance` test.